### PR TITLE
R file with a couple of versions of the laplacian interpolator.

### DIFF
--- a/radius-map.r
+++ b/radius-map.r
@@ -97,22 +97,12 @@ speedimage <- function(disttransfile) {
 
 main <- function() {
     args <- commandArgs(TRUE)
-    if(length(args) != 5)
+    if(length(args) != 2)
     	{
-  	stop("Missing Parameters: <binary-input> <mnimasked> <lrmask> <seed-output> <regionfill3DB-output>")
+  	stop("Missing Parameters: <binary-input> <speed-output>")
 	}
-
-    dt <- ReadImage(args[1], "sitkFloat32")
-
-    system.time( s <- speedimage(args[1]))
-    WriteImage(s, args[4])
-    
-
-    mni <- ReadImage(args[2])
-    msk <- ReadImage(args[3], "sitkUInt8")
-
-    WriteImage(regionfill3DB(mni, msk), args[5])
-    
+    s <- speedimage(args[1])
+    WriteImage(s, args[2])
 }
 
 main()

--- a/radius-map.r
+++ b/radius-map.r
@@ -97,12 +97,22 @@ speedimage <- function(disttransfile) {
 
 main <- function() {
     args <- commandArgs(TRUE)
-    if(length(args) != 2)
+    if(length(args) != 5)
     	{
-  	stop("Missing Parameters: <binary-input> <speed-output>")
+  	stop("Missing Parameters: <binary-input> <mnimasked> <lrmask> <seed-output> <regionfill3DB-output>")
 	}
-    s <- speedimage(args[1])
-    WriteImage(s, args[2])
+
+    dt <- ReadImage(args[1], "sitkFloat32")
+
+    system.time( s <- speedimage(args[1]))
+    WriteImage(s, args[4])
+    
+
+    mni <- ReadImage(args[2])
+    msk <- ReadImage(args[3], "sitkUInt8")
+
+    WriteImage(regionfill3DB(mni, msk), args[5])
+    
 }
 
 main()


### PR DESCRIPTION
The two functions are regionfill3D and regionfill3DB. They are clones
of the matlab function regionfill, but for 3D.

The driver function is speedimage, which is needs to be given a
distance transform image.

The regionfill3D ends up creating an n x n matrix (sparse), where n is
the number of voxels in the 3D image. regionfill3DB creates an m x m
matrix (sparse), where m is the number of voxels in the mask, after
dilating by 1.

Setting up the matrix structure is messier in regionfill3DB, but the
final matrix will be much smaller. Not yet sure how much practical difference
this will make.