### PR TITLE
Rfixes

### DIFF
--- a/radius-map.r
+++ b/radius-map.r
@@ -97,7 +97,7 @@ main <- function() {
     args <- commandArgs(TRUE)
     if(length(args) != 3)
     	{
-  	stop("Missing Parameters: <binary-input> <seed-output> <wth-output>")
+  	stop("Missing Parameters: <binary-input> <speed-output>")
 	}
     s <- speedimage(args[1])
     WriteImages(s, args[2])

--- a/radius-map.r
+++ b/radius-map.r
@@ -99,23 +99,8 @@ main <- function() {
     	{
   	stop("Missing Parameters: <binary-input> <seed-output> <wth-output>")
 	}
-
-    dt <- ReadImage(args[1], "sitkFloat32")
-
     s <- speedimage(args[1])
     WriteImages(s, args[2])
-    
-    # White top hat
-
-    wth <- WhiteTopHat(dt)
-    #wth <- wth > 0
-
-    wtha <- as.array(wth)
-    wtha <- wtha[wtha > 0]
-    hist(wtha, 50)
-    
-    gc()
-    WriteImage(wth, args[3])
 }
 
 main()


### PR DESCRIPTION
Slight mods to main(), removing some of my test code.

Recommend exploring regionfill3DB, from the original PR. It is a drop-in replacement for regionfill3D and should use considerably less RAM. Call from speedimage needs to be changed to match.